### PR TITLE
Pulse detector synthesis fix

### DIFF
--- a/src/rtl/pulse_detector/pulse_detector.sv
+++ b/src/rtl/pulse_detector/pulse_detector.sv
@@ -14,16 +14,21 @@
 module pulse_detector
 (
 	input clk,
-	input async_rst,
+	input async_rst_n,
 	input pulse_in,
 	output pulse_out
 );
 
 logic q0,q1;
+logic q1_async_rst_n;
 
+//fix for synthesis
+always_comb begin
+	q1_async_rst_n = q1 | ~async_rst_n ;
+end
 
-always_ff @ ( posedge pulse_in, posedge q1, negedge async_rst ) begin
-	if( q1 | ~async_rst ) begin
+always_ff @ ( posedge pulse_in, posedge q1_async_rst_n ) begin
+	if( q1_async_rst_n ) begin
 		q0 <= '0;
 	end
 	else begin
@@ -31,8 +36,8 @@ always_ff @ ( posedge pulse_in, posedge q1, negedge async_rst ) begin
 	end
 end
 
-always_ff @ ( posedge clk, negedge async_rst ) begin
-	if( ~async_rst ) begin
+always_ff @ ( posedge clk, negedge async_rst_n ) begin
+	if( ~async_rst_n ) begin
 		q1 <= 'b0;
 	end
 	else begin


### PR DESCRIPTION
Modified the sensitivity list and if conditions to enable synthesis
Issues : 
if condition can only contain == or != operator
all the items in the sensitivity list should be validated in an if condition